### PR TITLE
🐛 Fix refactor command crashing on non-string tool results

### DIFF
--- a/lua/agentic/adapters/claude.lua
+++ b/lua/agentic/adapters/claude.lua
@@ -97,6 +97,9 @@ function Claude:format_event(event)
 
   if event.type == "user" and event.tool_use_result then
     local result = event.tool_use_result
+    if type(result) ~= "string" then
+      result = vim.fn.json_encode(result)
+    end
     if result:match("^Error:") then
       return string.format("\n> %s\n", result)
     end

--- a/lua/agentic/adapters/claude.lua
+++ b/lua/agentic/adapters/claude.lua
@@ -153,8 +153,8 @@ function Claude:ask(prompt, context, callback, on_event)
     end
 
     if on_event then
-      local formatted = self:format_event(event)
-      if formatted then
+      local format_ok, formatted = pcall(self.format_event, self, event)
+      if format_ok and formatted then
         vim.schedule(function()
           on_event(formatted)
         end)

--- a/tests/adapters/claude_spec.lua
+++ b/tests/adapters/claude_spec.lua
@@ -335,6 +335,16 @@ local x = 1
       assert.is_truthy(result:match("truncated"))
     end)
 
+    it("handles non-string tool_use_result", function()
+      local event = {
+        type = "user",
+        tool_use_result = { content = "test", success = true },
+      }
+      local result = adapter:format_event(event)
+      assert.is_truthy(result:match("```"))
+      assert.is_truthy(result:match("content"))
+    end)
+
     it("formats result event with duration and cost", function()
       local event = {
         type = "result",


### PR DESCRIPTION
## Summary
- Fix `attempt to call method 'match' (a nil value)` error when `tool_use_result` is not a string (e.g., a table/object)
- Add pcall around `format_event` so one malformed event doesn't break streaming
- Errors in event formatting are now silently ignored, allowing streaming to continue

## Test plan
- [x] Run `make test` - all 44 tests pass
- [x] Run `make lint` - no warnings
- [ ] Manual test `:PamojaRefactor` with various inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)